### PR TITLE
CircleCI: Only deploy on TAG

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -59,11 +59,24 @@ workflows:
       - create-build:
           requires:
             - install-dependencies
+          filters:
+            tags:
+              only: /^v.*/
       - sync-to-s3:
           context: AWS
           requires:
             - create-build
+          filters:
+            branches:
+              ignore: /.*/
+            tags:
+              only: /^v.*/
       - create-cloudfront-invalidation:
           context: AWS
           requires:
             - sync-to-s3
+          filters:
+            branches:
+              ignore: /.*/
+            tags:
+              only: /^v.*/


### PR DESCRIPTION
Changed the pipeline so it `install-dependencies` and `creates-a-build` on every commit.

It will only deploy to S3 and create an CloudFront invalidation when a new version is created.